### PR TITLE
fixing load_from_file error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(SubCommand::with_name("truecase")
-                .about("Create a truecasing model based on training data")
+                .about("Perform truecasing on a file containing sentences that need to be truecased")
                 .arg(
                     Arg::with_name("model")
                         .short("m")

--- a/src/truecase.rs
+++ b/src/truecase.rs
@@ -44,7 +44,7 @@ impl Model {
     /// Load a previously saved model from a file
     pub fn load_from_file(path: impl AsRef<Path>) -> Result<Self, ModelLoadingError> {
         let mut vec = Vec::new();
-        File::open(path)?.read(&mut vec)?;
+        File::open(path)?.read_to_end(&mut vec)?;
         Model::deserialize(&vec)
     }
 


### PR DESCRIPTION
The following pulling request suggests changes to fix an error that occurs when performing truecasing using the CLI tool and a pretrained model. I also suggest a simple change to the `about` of the truecase option in the main.rs for consistency.

The error in question:
```
Error: Couldn't load model from model.json

Caused by:
    0: malformed model file: EOF while parsing a value at line 1 column 0
    1: EOF while parsing a value at line 1 column 0
```

Proposed fix:

change the `read` function to `read_to_end`.
